### PR TITLE
pbar.set_description formatting issue with avg_loss.get_metric()

### DIFF
--- a/upper_train.py
+++ b/upper_train.py
@@ -433,7 +433,7 @@ def main(args):
             avg_loss.update(total_loss)
 
             pbar.set_description(f'epoch: {epoch: d}, '
-                                 f'avg_loss: {avg_loss.get_metric(): 0.4f}, '
+                                 f'avg_loss: {avg_loss.get_metric()[0]: 0.4f},  {avg_loss.get_metric()[1]: 0.8f} '
                                  f'loss: {loss:0.3f}, '
                                  f'valid loss: {valid_loss:0.3f}')
 


### PR DESCRIPTION
Fixed TypeError in progress bar description

When attempting to recreate the results with the progress bar using:

pbar.set_description(f'epoch: {epoch: d}, ' f'avg_loss: {avg_loss.get_metric(): 0.4f}, ' f'loss: {loss:0.3f}, ' f'valid loss: {valid_loss:0.3f}')

I encountered a `TypeError` regarding an unsupported format string passed to `list.__format__`. This issue arose because `avg_loss.get_metric()` returns a list of two values. Upon reviewing the implementation of the ExponentialMovingAverage utility, it was indeed designed to return a list.

It appears there was a minor bug in the way the progress bar's description was being set. To resolve this, I've updated the code segment to correctly format each element of the list returned by `avg_loss.get_metric()`:

pbar.set_description(f'epoch: {epoch:d}, 'f'avg_loss[0]: {avg_loss.get_metric()[0]:0.4f}, avg_loss[1]: {avg_loss.get_metric()[1]:0.4f}, 'f'loss: {loss:0.3f}, 'f'valid loss: {valid_loss:0.3f} ')

This change ensures that both values from the `avg_loss.get_metric()` list are individually formatted and displayed correctly in the progress bar description.